### PR TITLE
feat: add Terraform and plan/apply workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 		},
 		"ghcr.io/devcontainers/features/terraform:1": {
 			"version": "1.10.5",
+			"terragrunt": "0.73.13",
 			"tflint": "latest"
 		},
     	"ghcr.io/shyim/devcontainers-features/bun:0": {}

--- a/.github/workflows/app-pull-request.yml
+++ b/.github/workflows/app-pull-request.yml
@@ -11,6 +11,9 @@ defaults:
     shell: bash
     working-directory: ./app
 
+permissions:
+  contents: read
+
 jobs:
   app-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/backstage-catalog-helper.yml
+++ b/.github/workflows/backstage-catalog-helper.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update-catalog-info:
     runs-on: ubuntu-latest

--- a/.github/workflows/export_github_data.yml
+++ b/.github/workflows/export_github_data.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "20 7 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   export-data:
     runs-on: ubuntu-latest

--- a/.github/workflows/s3-backup.yml
+++ b/.github/workflows/s3-backup.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   s3-backup:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - "**/*.sh"
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -1,0 +1,48 @@
+name: Terraform Apply Production
+
+on:
+  release:
+    types:
+    - published
+
+env:
+  AWS_REGION: ca-central-1
+  TERRAFORM_VERSION: 1.10.5
+  TERRAGRUNT_VERSION: 0.73.13
+  TF_INPUT: false
+  TF_VAR_hosted_zone_id: ${{ secrets.PROD_HOSTED_ZONE_ID }}
+  TF_VAR_wordpress_user: ${{ secrets.PROD_WORDPRESS_USER }}
+  TF_VAR_wordpress_password: ${{ secrets.PROD_WORDPRESS_PASSWORD }}
+  
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terragrunt-apply:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Audit DNS requests
+        uses: cds-snc/dns-proxy-action@main
+        env:
+          DNS_PROXY_FORWARDTOSENTINEL: "true"
+          DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-docs-release
+          role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Apply Terraform
+        working-directory: terragrunt/env/prod
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-apply-staging.yml
+++ b/.github/workflows/tf-apply-staging.yml
@@ -1,0 +1,56 @@
+name: Terraform Apply Staging
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "terragrunt/aws/**"
+      - "terragrunt/env/staging/**"
+      - "terragrunt/env/common/**"
+      - "terragrunt/env/root.hcl"
+      - ".github/workflows/tf-apply-staging.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  TERRAFORM_VERSION: 1.10.5
+  TERRAGRUNT_VERSION: 0.73.13
+  TF_INPUT: false
+  TF_VAR_hosted_zone_id: ${{ secrets.STAGING_HOSTED_ZONE_ID }}
+  TF_VAR_wordpress_user: ${{ secrets.STAGING_WORDPRESS_USER }}
+  TF_VAR_wordpress_password: ${{ secrets.STAGING_WORDPRESS_PASSWORD }}
+  
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terragrunt-apply:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Audit DNS requests
+        uses: cds-snc/dns-proxy-action@main
+        env:
+          DNS_PROXY_FORWARDTOSENTINEL: "true"
+          DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-docs-apply 
+          role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Apply Terraform
+        working-directory: terragrunt/env/staging
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -1,0 +1,58 @@
+name: Terraform Plan Production
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "version.txt"
+
+env:
+  AWS_REGION: ca-central-1
+  TERRAFORM_VERSION: 1.10.5
+  TERRAGRUNT_VERSION: 0.73.13
+  TF_SUMMARIZE_VERSION: 0.3.5
+  TF_INPUT: false
+  TF_VAR_hosted_zone_id: ${{ secrets.PROD_HOSTED_ZONE_ID }}
+  TF_VAR_wordpress_user: ${{ secrets.PROD_WORDPRESS_USER }}
+  TF_VAR_wordpress_password: ${{ secrets.PROD_WORDPRESS_PASSWORD }}
+
+  
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform-plan:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit DNS requests
+        uses: cds-snc/dns-proxy-action@main
+        env:
+          DNS_PROXY_FORWARDTOSENTINEL: "true"
+          DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-docs-plan 
+          role-session-name: TFPlan
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform plan
+        uses: cds-snc/terraform-plan@d79bcf0eccf632a0ad9e9193072b42c970766c5b # v3.3.1
+        with:
+          comment-delete: true
+          comment-title: "Production"
+          directory: "terragrunt/env/prod"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          terragrunt: true

--- a/.github/workflows/tf-plan-staging.yml
+++ b/.github/workflows/tf-plan-staging.yml
@@ -1,0 +1,58 @@
+name: Terraform Plan Staging
+on:
+  pull_request:
+    paths:
+      - "terragrunt/aws/**"
+      - "terragrunt/env/staging/**"
+      - "terragrunt/env/common/**"
+      - "terragrunt/env/root.hcl"
+      - ".github/workflows/tf-plan-staging.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  TERRAFORM_VERSION: 1.10.5
+  TERRAGRUNT_VERSION: 0.73.13
+  TF_SUMMARIZE_VERSION: 0.3.5
+  TF_INPUT: false
+  TF_VAR_hosted_zone_id: ${{ secrets.STAGING_HOSTED_ZONE_ID }}
+  TF_VAR_wordpress_user: ${{ secrets.STAGING_WORDPRESS_USER }}
+  TF_VAR_wordpress_password: ${{ secrets.STAGING_WORDPRESS_PASSWORD }}
+  
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform-plan:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit DNS requests
+        uses: cds-snc/dns-proxy-action@main
+        env:
+          DNS_PROXY_FORWARDTOSENTINEL: "true"
+          DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-docs-plan 
+          role-session-name: TFPlan
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform plan
+        uses: cds-snc/terraform-plan@d79bcf0eccf632a0ad9e9193072b42c970766c5b # v3.3.1
+        with:
+          comment-delete: true
+          comment-title: "Staging"
+          directory: "terragrunt/env/staging"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          terragrunt: true

--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -3,6 +3,10 @@ name: Workflow failure
 on:
   workflow_run:
     workflows:
+      - "Docker build and push Production"
+      - "Docker build and push Staging"
+      - "Docker deploy Production"
+      - "Docker deploy Staging"
       - "Terraform Apply Production"
       - "Terraform Apply Staging"
     types:

--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -8,6 +8,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -1,0 +1,19 @@
+name: Workflow failure
+
+on:
+  workflow_run:
+    workflows:
+      - "Terraform Apply Production"
+      - "Terraform Apply Staging"
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Notify Slack
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Superset workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 node_modules
 
 # Terraform
+.terragrunt-cache
 **/.terraform/*
 *.tfstate
 *.tfstate.*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Documentation site for [CDS Superset](https://superset.cds-snc.ca/). Content is managed in WordPress and retrieved via its API.
 
-The app is built using [Express.js](https://expressjs.com/) and uses the [GC Design System](https://design-system.alpha.canada.ca/) for its frontend. Hosting is done using a Lambda function with content caching provided by CloudFront.
+The app is built using [Express.js](https://expressjs.com/) and uses the [GC Design System](https://design-system.alpha.canada.ca/) for its frontend. Hosting is done using a [Lambda function](./terragrunt/aws/lambda.tf) with content caching provided by a [CloudFront distribution](./terragrunt/aws/cloudfront.tf).
 
 ## Running locally
 ```sh

--- a/terragrunt/aws/cloudfront.tf
+++ b/terragrunt/aws/cloudfront.tf
@@ -1,0 +1,91 @@
+resource "aws_cloudfront_distribution" "superset_docs" {
+  enabled     = true
+  aliases     = [var.domain]
+  price_class = "PriceClass_100"
+
+  origin {
+    domain_name = local.superset_docs_function_url
+    origin_id   = module.superset_docs.function_name
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_read_timeout    = 60
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods  = ["GET", "HEAD"]
+
+    forwarded_values {
+      query_string = true
+      cookies {
+        forward = "none"
+      }
+    }
+
+    target_origin_id       = module.superset_docs.function_name
+    viewer_protocol_policy = "redirect-to-https"
+
+    min_ttl     = 1
+    default_ttl = 86400 # 24 hours
+    max_ttl     = 86400 # 24 hours
+    compress    = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.superset_docs.certificate_arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_acm_certificate" "superset_docs" {
+  provider = aws.us-east-1
+
+  domain_name               = var.domain
+  subject_alternative_names = ["*.${var.domain}"]
+  validation_method         = "DNS"
+
+  tags = local.common_tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "superset_docs_cert_validation" {
+  zone_id = var.hosted_zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.superset_docs.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "superset_docs" {
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.superset_docs.arn
+  validation_record_fqdns = [for record in aws_route53_record.superset_docs_cert_validation : record.fqdn]
+}

--- a/terragrunt/aws/ecr.tf
+++ b/terragrunt/aws/ecr.tf
@@ -1,0 +1,10 @@
+resource "aws_ecr_repository" "superset_docs" {
+  name                 = var.product_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = local.common_tags
+}

--- a/terragrunt/aws/lambda.tf
+++ b/terragrunt/aws/lambda.tf
@@ -1,0 +1,28 @@
+module "superset_docs" {
+  source    = "github.com/cds-snc/terraform-modules//lambda?ref=v10.3.0"
+  name      = var.product_name
+  ecr_arn   = aws_ecr_repository.superset_docs.arn
+  image_uri = "${aws_ecr_repository.superset_docs.repository_url}:latest"
+
+  architectures          = ["arm64"]
+  memory                 = 4096
+  timeout                = 10
+  enable_lambda_insights = true
+
+  environment_variables = {
+    MENU_ID_EN         = var.menu_id_en
+    MENU_ID_FR         = var.menu_id_fr
+    SITE_NAME_EN       = var.site_name_en
+    SITE_NAME_FR       = var.site_name_fr
+    WORDPRESS_URL      = var.wordpress_url
+    WORDPRESS_USER     = var.wordpress_user
+    WORDPRESS_PASSWORD = var.wordpress_password
+  }
+
+  billing_tag_value = var.billing_code
+}
+
+resource "aws_lambda_function_url" "superset_docs" {
+  function_name      = module.superset_docs.function_name
+  authorization_type = "NONE"
+}

--- a/terragrunt/aws/locals.tf
+++ b/terragrunt/aws/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  common_tags = {
+    Terraform  = "true"
+    CostCentre = var.billing_code
+  }
+  superset_docs_function_url = split("/", aws_lambda_function_url.superset_docs.function_url)[2]
+}

--- a/terragrunt/aws/oidc.tf
+++ b/terragrunt/aws/oidc.tf
@@ -1,0 +1,41 @@
+locals {
+  cds_superset_docs_release = "cds-superset-docs-release"
+}
+
+#
+# Create the OIDC roles used by the GitHub workflows
+# The roles can be assumed by the GitHub workflows according to the `claim`
+# attribute of each role.
+# 
+module "github_workflow_roles" {
+  count = var.env == "prod" ? 1 : 0
+
+  source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v10.3.0"
+  billing_tag_value = var.billing_code
+  roles = [
+    {
+      name      = local.cds_superset_docs_release
+      repo_name = "cds-superset-docs"
+      claim     = "ref:refs/tags/v*"
+    }
+  ]
+}
+
+#
+# Attach polices to the OIDC roles to grant them permissions.  These
+# attachments are scoped to only the environments that require the role.
+#
+resource "aws_iam_role_policy_attachment" "cds_superset_docs_release" {
+  count = var.env == "prod" ? 1 : 0
+
+  role       = local.cds_superset_docs_release
+  policy_arn = data.aws_iam_policy.admin.arn
+  depends_on = [
+    module.github_workflow_roles[0]
+  ]
+}
+
+data "aws_iam_policy" "admin" {
+  # checkov:skip=CKV_AWS_275:This policy is required for the Terraform apply
+  name = "AdministratorAccess"
+}

--- a/terragrunt/aws/route53.tf
+++ b/terragrunt/aws/route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_record" "superset_docs_A" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.superset_docs.domain_name
+    zone_id                = aws_cloudfront_distribution.superset_docs.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_health_check" "superset_docs" {
+  fqdn              = local.superset_docs_function_url
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "5"
+  request_interval  = "30"
+  regions           = ["us-east-1", "us-west-1", "us-west-2"]
+
+  tags = local.common_tags
+}

--- a/terragrunt/aws/variables.tf
+++ b/terragrunt/aws/variables.tf
@@ -1,0 +1,42 @@
+variable "hosted_zone_id" {
+  description = "The Route53 hosted zone ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "menu_id_en" {
+  description = "The English menu to display"
+  type        = string
+}
+
+variable "menu_id_fr" {
+  description = "The French menu to display"
+  type        = string
+}
+
+variable "site_name_en" {
+  description = "The English site name"
+  type        = string
+}
+
+variable "site_name_fr" {
+  description = "The French site name"
+  type        = string
+}
+
+variable "wordpress_url" {
+  description = "The URL of the WordPress site"
+  type        = string
+}
+
+variable "wordpress_user" {
+  description = "The WordPress admin user"
+  type        = string
+  sensitive   = true
+}
+
+variable "wordpress_password" {
+  description = "The WordPress admin password"
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -1,0 +1,34 @@
+variable "account_id" {
+  description = "(Required) The account ID to perform actions on."
+  type        = string
+}
+
+variable "billing_code" {
+  description = "The billing code to tag our resources with"
+  type        = string
+}
+
+variable "cbs_satellite_bucket_name" {
+  description = "The name of the Cloud Based Sensor satellite bucket"
+  type        = string
+}
+
+variable "domain" {
+  description = "The domain to use for the service."
+  type        = string
+}
+
+variable "env" {
+  description = "The current running environment"
+  type        = string
+}
+
+variable "product_name" {
+  description = "(Required) The name of the product you are deploying."
+  type        = string
+}
+
+variable "region" {
+  description = "The current AWS region"
+  type        = string
+}

--- a/terragrunt/env/common/provider.tf
+++ b/terragrunt/env/common/provider.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region              = var.region
+  allowed_account_ids = [var.account_id]
+}
+
+provider "aws" {
+  alias               = "us-east-1"
+  region              = "us-east-1"
+  allowed_account_ids = [var.account_id]
+}

--- a/terragrunt/env/prod/.terraform.lock.hcl
+++ b/terragrunt/env/prod/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.88.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:8So0IR8jwKx8WhVuD1LDsbeMTe78/SF5g4d7z5C6+C4=",
+    "h1:CtUi38/zeD7FmxC327T/r1RGze7GNrC8QFaSSBy7u9M=",
+    "h1:Gsl/jrA6UmJI6iJg5HtQuZWERwWFyl8361jicsGEOj4=",
+    "h1:H9Ur5AHP1XwvGS7tJvPMo7JNFxHYwxsYtXBML0gas9A=",
+    "h1:Lox8X0csC/88j8PokcK1rTRDLBYpSASQyurE27e6C+Y=",
+    "h1:NpZJqGhTv3LsjL0Jg8OBpIto5cbyahoyn6bNlQ0XbVI=",
+    "h1:PXaP+z5Z9pcUUcJqS6ea09wR/cscBq1F9jRsNqe39rM=",
+    "h1:Uqmvemsy5d+fqf21wwnqQOx/RQg0mJ3gXdWRWQs7cKc=",
+    "h1:YwZyjmqgCzgSq5YzfPmb8Iqy5u/7SiJECeUyQK8kma0=",
+    "h1:aXxdTbDqZ7sIv0eKcpB1iNGH+gjwYjYZuJAAtXKSkTU=",
+    "h1:nks+LOLQf0gfh7EZCqpWErw9/03yqYDEaGxYqUfEc78=",
+    "h1:u8hinU3pUne1S4oijYQHzx4ynQDRzJ8gpwgxtDu8KlA=",
+    "h1:vZVMI4zaLpESWoN79JGDBTqTxM+bt5PoIx/bt0NC2+A=",
+    "h1:wZQjYp5BEHgwnX2sb7OTiiXxueVJOVFtkb4K1GVAtL4=",
+    "zh:24f852b1cca276d91f950cb7fb575cacc385f55edccf4beec1f611cdd7626cf5",
+    "zh:2a3b3f5ac513f8d6448a31d9619f8a96e0597dd354459de3a4698e684c909f96",
+    "zh:3700499885a8e0e532eccba3cb068340e411cf9e616bf8a59e815d3b62ca3e46",
+    "zh:4aab3605468244a74cbde66784ea1d30dc0fc6caf26d1b099427ecd5790f7c4d",
+    "zh:74eca9314d6dd80b215d7bc1c4be37d81e1045d625d5b512995f3a352d7a43bc",
+    "zh:77d9a06c63a4ad615bc97f67f948250397267f15698ebb2547fbdd20f734983c",
+    "zh:82d6aaef1eb0caf9ca451887fdbdcff10ab09318b1d60faa883a013283ab2b15",
+    "zh:8dbcfb121b887ce8572f5ab8174d592a729390ca32dc5fdacac4c7c1c508411a",
+    "zh:95d51e80b55ff9064f5c1bc61d78f992e2f89c986ba2b10546ea4461d35c24f9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9ead5de0e123020926a0edaf88d9eed5cb86afe438a875528f6d11d0d27eed73",
+    "zh:ab7c940cbb2081314f4af3cdd61ed2c1d59fd7a60fa3db27770887d63072fbdd",
+    "zh:d52cd68006fd6fa8d028cdf569a6620fbc31726019beb7c75affa8764622d398",
+    "zh:f179ca86ad5d5fb88dfd8e8e7c448f2c0ad550d22152f939b8465baeaf9289e9",
+    "zh:f54dda271fa6dfee06537066278669a3f92c872e7dfa5a0184cd9117f7e47b8c",
+  ]
+}

--- a/terragrunt/env/prod/env_vars.hcl
+++ b/terragrunt/env/prod/env_vars.hcl
@@ -1,0 +1,7 @@
+inputs = {
+  account_id   = "066023111852"
+  domain       = "docs.superset.cds-snc.ca"
+  env          = "prod"
+  region       = "ca-central-1"
+  product_name = "cds-superset-docs"
+}

--- a/terragrunt/env/prod/terragrunt.hcl
+++ b/terragrunt/env/prod/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = "../..//aws"
+}
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+inputs = {
+  menu_id_en    = "9"
+  menu_id_fr    = "10"
+  site_name_en  = "Superset Docs"
+  site_name_fr  = "Docs de Superset"
+  wordpress_url = "https://articles.alpha.canada.ca/pcs-superset"
+}

--- a/terragrunt/env/root.hcl
+++ b/terragrunt/env/root.hcl
@@ -1,0 +1,43 @@
+locals {
+  vars         = read_terragrunt_config("./env_vars.hcl")
+  billing_code = "${local.vars.inputs.product_name}-${local.vars.inputs.env}"
+}
+
+inputs = {
+  account_id                = local.vars.inputs.account_id
+  domain                    = local.vars.inputs.domain
+  env                       = local.vars.inputs.env
+  product_name              = local.vars.inputs.product_name
+  region                    = local.vars.inputs.region
+  billing_code              = local.billing_code
+  cbs_satellite_bucket_name = "cbs-satellite-${local.vars.inputs.account_id}"
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    encrypt             = true
+    bucket              = "${local.billing_code}-tf"
+    use_lockfile        = true
+    region              = "ca-central-1"
+    key                 = "./terraform.tfstate"
+    s3_bucket_tags      = { CostCenter : local.billing_code }
+    dynamodb_table_tags = { CostCenter : local.billing_code }
+  }
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = file("./common/provider.tf")
+}
+
+generate "common_variables" {
+  path      = "common_variables.tf"
+  if_exists = "overwrite"
+  contents  = file("./common/common_variables.tf")
+}

--- a/terragrunt/env/staging/.terraform.lock.hcl
+++ b/terragrunt/env/staging/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.88.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:8So0IR8jwKx8WhVuD1LDsbeMTe78/SF5g4d7z5C6+C4=",
+    "h1:CtUi38/zeD7FmxC327T/r1RGze7GNrC8QFaSSBy7u9M=",
+    "h1:Gsl/jrA6UmJI6iJg5HtQuZWERwWFyl8361jicsGEOj4=",
+    "h1:H9Ur5AHP1XwvGS7tJvPMo7JNFxHYwxsYtXBML0gas9A=",
+    "h1:Lox8X0csC/88j8PokcK1rTRDLBYpSASQyurE27e6C+Y=",
+    "h1:NpZJqGhTv3LsjL0Jg8OBpIto5cbyahoyn6bNlQ0XbVI=",
+    "h1:PXaP+z5Z9pcUUcJqS6ea09wR/cscBq1F9jRsNqe39rM=",
+    "h1:Uqmvemsy5d+fqf21wwnqQOx/RQg0mJ3gXdWRWQs7cKc=",
+    "h1:YwZyjmqgCzgSq5YzfPmb8Iqy5u/7SiJECeUyQK8kma0=",
+    "h1:aXxdTbDqZ7sIv0eKcpB1iNGH+gjwYjYZuJAAtXKSkTU=",
+    "h1:nks+LOLQf0gfh7EZCqpWErw9/03yqYDEaGxYqUfEc78=",
+    "h1:u8hinU3pUne1S4oijYQHzx4ynQDRzJ8gpwgxtDu8KlA=",
+    "h1:vZVMI4zaLpESWoN79JGDBTqTxM+bt5PoIx/bt0NC2+A=",
+    "h1:wZQjYp5BEHgwnX2sb7OTiiXxueVJOVFtkb4K1GVAtL4=",
+    "zh:24f852b1cca276d91f950cb7fb575cacc385f55edccf4beec1f611cdd7626cf5",
+    "zh:2a3b3f5ac513f8d6448a31d9619f8a96e0597dd354459de3a4698e684c909f96",
+    "zh:3700499885a8e0e532eccba3cb068340e411cf9e616bf8a59e815d3b62ca3e46",
+    "zh:4aab3605468244a74cbde66784ea1d30dc0fc6caf26d1b099427ecd5790f7c4d",
+    "zh:74eca9314d6dd80b215d7bc1c4be37d81e1045d625d5b512995f3a352d7a43bc",
+    "zh:77d9a06c63a4ad615bc97f67f948250397267f15698ebb2547fbdd20f734983c",
+    "zh:82d6aaef1eb0caf9ca451887fdbdcff10ab09318b1d60faa883a013283ab2b15",
+    "zh:8dbcfb121b887ce8572f5ab8174d592a729390ca32dc5fdacac4c7c1c508411a",
+    "zh:95d51e80b55ff9064f5c1bc61d78f992e2f89c986ba2b10546ea4461d35c24f9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9ead5de0e123020926a0edaf88d9eed5cb86afe438a875528f6d11d0d27eed73",
+    "zh:ab7c940cbb2081314f4af3cdd61ed2c1d59fd7a60fa3db27770887d63072fbdd",
+    "zh:d52cd68006fd6fa8d028cdf569a6620fbc31726019beb7c75affa8764622d398",
+    "zh:f179ca86ad5d5fb88dfd8e8e7c448f2c0ad550d22152f939b8465baeaf9289e9",
+    "zh:f54dda271fa6dfee06537066278669a3f92c872e7dfa5a0184cd9117f7e47b8c",
+  ]
+}

--- a/terragrunt/env/staging/env_vars.hcl
+++ b/terragrunt/env/staging/env_vars.hcl
@@ -1,0 +1,7 @@
+inputs = {
+  account_id   = "257394494478"
+  domain       = "docs.superset.cdssandbox.xyz"
+  env          = "staging"
+  region       = "ca-central-1"
+  product_name = "cds-superset-docs"
+}

--- a/terragrunt/env/staging/terragrunt.hcl
+++ b/terragrunt/env/staging/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = "../..//aws"
+}
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+inputs = {
+  menu_id_en    = "9"
+  menu_id_fr    = "10"
+  site_name_en  = "Superset Docs"
+  site_name_fr  = "Docs de Superset"
+  wordpress_url = "https://articles.alpha.canada.ca/pcs-superset"
+}


### PR DESCRIPTION
# Summary
Add the Terraform and GitHub workflows required to manage the doc site's Lambda function and CloudFront distribution.

# Related
- https://github.com/cds-snc/platform-core-services/issues/667