### PR TITLE
feat: add a WAF ACL for the CloudFront distribution

### DIFF
--- a/terragrunt/aws/cloudfront.tf
+++ b/terragrunt/aws/cloudfront.tf
@@ -2,6 +2,7 @@ resource "aws_cloudfront_distribution" "superset_docs" {
   enabled     = true
   aliases     = [var.domain]
   price_class = "PriceClass_100"
+  web_acl_id  = aws_wafv2_web_acl.superset_docs.arn
 
   origin {
     domain_name = local.superset_docs_function_url

--- a/terragrunt/aws/ecr.tf
+++ b/terragrunt/aws/ecr.tf
@@ -8,3 +8,50 @@ resource "aws_ecr_repository" "superset_docs" {
 
   tags = local.common_tags
 }
+
+resource "aws_ecr_lifecycle_policy" "superset_docs" {
+  repository = aws_ecr_repository.superset_docs.name
+  policy = jsonencode({
+    "rules" : [
+      {
+        "rulePriority" : 1,
+        "description" : "Keep last 30 release tagged images",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["v"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 30
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      },
+      {
+        "rulePriority" : 10,
+        "description" : "Keep last 10 git SHA tagged images",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["sha-"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 10
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      },
+      {
+        "rulePriority" : 20,
+        "description" : "Expire untagged images older than 7 days",
+        "selection" : {
+          "tagStatus" : "untagged",
+          "countType" : "sinceImagePushed",
+          "countUnit" : "days",
+          "countNumber" : 7
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -1,0 +1,182 @@
+resource "aws_wafv2_web_acl" "superset_docs" {
+  provider = aws.us-east-1
+
+  name        = "cds-superset-docs"
+  description = "Superset Docs CloudFront distribution"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "BlockLargeRequests"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      or_statement {
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              body {
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              cookies {
+                match_pattern {
+                  all {}
+                }
+                match_scope       = "ALL"
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              headers {
+                match_pattern {
+                  all {}
+                }
+                match_scope       = "ALL"
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+      }
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 10
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 20
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 30
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimit"
+    priority = 40
+
+    action {
+      block {
+        custom_response {
+          response_code = 429
+          response_header {
+            name  = "waf-block"
+            value = "RateLimit"
+          }
+        }
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 1000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "cds-superset-docs"
+    sampled_requests_enabled   = false
+  }
+
+  tags = local.common_tags
+}

--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -74,6 +74,12 @@ resource "aws_wafv2_web_acl" "superset_docs" {
         }
       }
     }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockLargeRequests"
+      sampled_requests_enabled   = true
+    }
   }
 
   rule {


### PR DESCRIPTION
# Summary
Add a WAF to protect the Docs site CloudFront distribution.

Add an ECR policy to remove old images that are no longer needed.

# Related
- https://github.com/cds-snc/platform-core-services/issues/667