### PR TITLE
fix: docker deploy staging workflow

### DIFF
--- a/.github/workflows/docker-deploy-staging.yml
+++ b/.github/workflows/docker-deploy-staging.yml
@@ -10,7 +10,7 @@ env:
   AWS_REGION: ca-central-1
   FUNCTION_NAME: cds-superset-docs
   REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/cds-superset-docs
-  GITHUB_SHA: ${{ github.sha }}
+  IMAGE_TAG: sha-${{ github.sha }}
 
 permissions:
   id-token: write
@@ -39,4 +39,4 @@ jobs:
       run: |
         aws lambda update-function-code \
           --function-name ${{ env.FUNCTION_NAME }} \
-          --image-uri $REGISTRY:${{ env.GITHUB_SHA }}  > /dev/null 2>&1
+          --image-uri $REGISTRY:${{ env.IMAGE_TAG }}  > /dev/null 2>&1

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -37,6 +37,6 @@ jobs:
           TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.REGISTRY }}:latest"
-          dockerfile_path: "./app/Dockerfile"
+          dockerfile_path: "app/Dockerfile"
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Summary
Add the missing `sha-` prefix to the Staging Docker image tag.

Also fixes the path to the Dockerfile in the vulnerability scan action.

# Related
- https://github.com/cds-snc/platform-core-services/issues/667