### PR TITLE
feat: cache invalidate after Docker image update

### DIFF
--- a/.github/workflows/cache-invalidate-prod.yml
+++ b/.github/workflows/cache-invalidate-prod.yml
@@ -1,0 +1,41 @@
+name: Cache invalidate Production
+
+on:
+  repository_dispatch:
+  workflow_run:
+    workflows: ["Docker deploy Production"]
+    types:
+    - completed
+
+env: 
+  AWS_REGION: ca-central-1
+
+permissions:
+  id-token: write
+
+jobs:
+  cache-invalidate:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Audit DNS requests
+      uses: cds-snc/dns-proxy-action@main
+      env:
+        DNS_PROXY_FORWARDTOSENTINEL: "true"
+        DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+        DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+    - name: Configure aws credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+      with:
+        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-docs-apply 
+        role-session-name: CacheInvalidate
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Invalidate CloudFront cache
+      run: |
+        DISTRIBUTION_ID="$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[?contains(@,'docs.superset')]].Id" --output text)"
+        aws cloudfront create-invalidation \
+          --distribution-id "$DISTRIBUTION_ID" \
+          --paths "/*"

--- a/.github/workflows/cache-invalidate-staging.yml
+++ b/.github/workflows/cache-invalidate-staging.yml
@@ -1,0 +1,41 @@
+name: Cache invalidate Staging
+
+on:
+  repository_dispatch:
+  workflow_run:
+    workflows: ["Docker deploy Staging"]
+    types:
+    - completed
+
+env: 
+  AWS_REGION: ca-central-1
+
+permissions:
+  id-token: write
+
+jobs:
+  cache-invalidate:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Audit DNS requests
+      uses: cds-snc/dns-proxy-action@main
+      env:
+        DNS_PROXY_FORWARDTOSENTINEL: "true"
+        DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+        DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+    - name: Configure aws credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+      with:
+        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-docs-apply 
+        role-session-name: CacheInvalidate
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Invalidate CloudFront cache
+      run: |
+        DISTRIBUTION_ID="$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[?contains(@,'docs.superset')]].Id" --output text)"
+        aws cloudfront create-invalidation \
+          --distribution-id "$DISTRIBUTION_ID" \
+          --paths "/*"


### PR DESCRIPTION
# Summary
Add Prod/Staging workflows that invalidate the CloudFront cache after a new Docker image is deployed.

# Related
- https://github.com/cds-snc/platform-core-services/issues/667