### PR TITLE
style: modify default margin for heading and text elements

### DIFF
--- a/app/public/styles.css
+++ b/app/public/styles.css
@@ -1,5 +1,10 @@
-gcds-container :is(ol, ul, p, hr, h2, h3, h4, h5, h6) {
-  margin-block-start: var(--gcds-spacing-300);
+gcds-container :is(h2, h3, h4, h5, h6) {
+  margin-block-start: var(--gcds-spacing-600);
+  margin-block-end: var(--gcds-spacing-300);
+}
+
+gcds-container :is(ol, ul, p, hr) {
+  margin-block-start: var(--gcds-spacing-0);
   margin-block-end: var(--gcds-spacing-300);
 }
 


### PR DESCRIPTION
# Summary | Résumé

Adding a small adjustment to the default margins of the heading and text elements to ensure consistency with the default values used by the corresponding GCDS components.

## Changes

- Heading `margin-block-start` was changed from `var(--gcds-spacing-300)` to `var(--gcds-spacing-600)`.
- List and paragraph `margin-block-start` was changed from `var(--gcds-spacing-300)` to `var(--gcds-spacing-0)`.