### PR TITLE
fix: reduce function memory

### DIFF
--- a/terragrunt/aws/lambda.tf
+++ b/terragrunt/aws/lambda.tf
@@ -5,7 +5,7 @@ module "superset_docs" {
   image_uri = "${aws_ecr_repository.superset_docs.repository_url}:latest"
 
   architectures          = ["arm64"]
-  memory                 = 4096
+  memory                 = 1024
   timeout                = 10
   enable_lambda_insights = true
 


### PR DESCRIPTION
# Summary
Reduce the function memory based.  The function invocation report shows that the average memory being used by invocations is 171MB.

The following query was used to determine memory use:
```
filter @type = "REPORT"
    | stats max(@memorySize / 1000 / 1000) as provisonedMemoryMB,
        min(@maxMemoryUsed / 1000 / 1000) as smallestMemoryRequestMB,
        avg(@maxMemoryUsed / 1000 / 1000) as avgMemoryUsedMB,
        max(@maxMemoryUsed / 1000 / 1000) as maxMemoryUsedMB,
        provisonedMemoryMB - maxMemoryUsedMB as overProvisionedMB
```


provisonedMemoryMB | smallestMemoryRequestMB | avgMemoryUsedMB | maxMemoryUsedMB | overProvisionedMB
-- | -- | -- | -- | --
1 | 4096 | 81 | 171.5032 | 227 | 3869

# Related
- [Example Lambda queries](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax-examples.html#CWL_QuerySyntax-examples-Lambda)
