### PR TITLE
feat: add an EventBridge rule to warm the function

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -9,16 +9,6 @@ data "aws_sns_topic" "cloudwatch_alert_ok" {
   name = "cloudwatch-alert-ok"
 }
 
-data "aws_sns_topic" "cloudwatch_alert_warning_us_east_1" {
-  provider = aws.us-east-1
-  name     = "cloudwatch-alert-warning"
-}
-
-data "aws_sns_topic" "cloudwatch_alert_ok_us_east_1" {
-  provider = aws.us-east-1
-  name     = "cloudwatch-alert-ok"
-}
-
 #
 # Errors logged
 #
@@ -71,30 +61,6 @@ resource "aws_cloudwatch_metric_alarm" "superset_docs_invocation_errors" {
 
   alarm_actions = [data.aws_sns_topic.cloudwatch_alert_warning.arn]
   ok_actions    = [data.aws_sns_topic.cloudwatch_alert_ok.arn]
-
-  tags = local.common_tags
-}
-
-resource "aws_cloudwatch_metric_alarm" "superset_docs_health_check" {
-  provider = aws.us-east-1
-
-  alarm_name          = "health-check-superset-docs"
-  alarm_description   = "`superset-docs` heath check has failed in a 2 minute period."
-  comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "HealthCheckStatus"
-  namespace           = "AWS/Route53"
-  period              = "60"
-  statistic           = "Minimum"
-  threshold           = "1"
-  treat_missing_data  = "notBreaching"
-
-  alarm_actions = [data.aws_sns_topic.cloudwatch_alert_warning_us_east_1.arn]
-  ok_actions    = [data.aws_sns_topic.cloudwatch_alert_ok_us_east_1.arn]
-
-  dimensions = {
-    HealthCheckId = aws_route53_health_check.superset_docs.id
-  }
 
   tags = local.common_tags
 }

--- a/terragrunt/aws/lambda.tf
+++ b/terragrunt/aws/lambda.tf
@@ -31,8 +31,8 @@ resource "aws_lambda_function_url" "superset_docs" {
 # Function warmer
 #
 resource "aws_cloudwatch_event_rule" "superset_docs" {
-  name        = "invoke-superset-docs"
-  description = "Keep the function toasty warm"
+  name                = "invoke-superset-docs"
+  description         = "Keep the function toasty warm"
   schedule_expression = "rate(5 minutes)"
 }
 

--- a/terragrunt/aws/route53.tf
+++ b/terragrunt/aws/route53.tf
@@ -9,15 +9,3 @@ resource "aws_route53_record" "superset_docs_A" {
     evaluate_target_health = false
   }
 }
-
-resource "aws_route53_health_check" "superset_docs" {
-  fqdn              = local.superset_docs_function_url
-  port              = 443
-  type              = "HTTPS"
-  resource_path     = "/"
-  failure_threshold = "5"
-  request_interval  = "30"
-  regions           = ["us-east-1", "us-west-1", "us-west-2"]
-
-  tags = local.common_tags
-}


### PR DESCRIPTION
# Summary
Replace the Route53 health check with an EventBridge rule that invokes the function every 5 minutes.  This will keep a warm instance of the function available to handle requests.

# Related
- https://github.com/cds-snc/platform-core-services/issues/681