### PR TITLE
fix: properly return a 404 when page not found

### DIFF
--- a/app/internal/api/wordpress.go
+++ b/app/internal/api/wordpress.go
@@ -31,6 +31,8 @@ type MenuResult struct {
 	Err       error
 }
 
+var ErrPageNotFound = fmt.Errorf("page not found")
+
 // NewWordPressClient creates and initializes a new WordPress API client.
 // It performs authentication and fetches menus concurrently during initialization.
 func NewWordPressClient(baseURL string, username string, password string, menuIdEn string, menuIdFr string) *WordPressClient {
@@ -168,7 +170,7 @@ func (c *WordPressClient) FetchPage(path string) (*models.WordPressPage, error) 
 	}
 
 	if len(pages) == 0 {
-		return nil, fmt.Errorf("page not found")
+		return nil, ErrPageNotFound
 	}
 
 	return &pages[0], nil

--- a/app/internal/handlers/page_test.go
+++ b/app/internal/handlers/page_test.go
@@ -215,7 +215,7 @@ func TestServeHTTP(t *testing.T) {
 			name:           "Path with file extension",
 			method:         "GET",
 			path:           "/about-us.html",
-			expectedStatus: http.StatusNotFound,
+			expectedStatus: http.StatusBadRequest,
 			expectError:    true,
 		},
 		{
@@ -327,7 +327,7 @@ func TestHandlePage(t *testing.T) {
 			testResponses: map[string]interface{}{
 				"pages/not-found": []models.WordPressPage{},
 			},
-			expectedStatus: http.StatusInternalServerError,
+			expectedStatus: http.StatusNotFound,
 		},
 	}
 


### PR DESCRIPTION
# Summary
Update the Page handler so that a 404 is returned when a WordPress page is not found.

Update the checks for invalid characters in the URL to only allow alphanumeric, slashes, dashed and underscores.
