### PR TITLE
fix: update CA geo restriction with Upptime header 

### DIFF
--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -13,6 +13,7 @@ env:
   TF_VAR_hosted_zone_id: ${{ secrets.PROD_HOSTED_ZONE_ID }}
   TF_VAR_wordpress_user: ${{ secrets.PROD_WORDPRESS_USER }}
   TF_VAR_wordpress_password: ${{ secrets.PROD_WORDPRESS_PASSWORD }}
+  TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
   
 permissions:
   id-token: write

--- a/.github/workflows/tf-apply-staging.yml
+++ b/.github/workflows/tf-apply-staging.yml
@@ -19,6 +19,7 @@ env:
   TF_VAR_hosted_zone_id: ${{ secrets.STAGING_HOSTED_ZONE_ID }}
   TF_VAR_wordpress_user: ${{ secrets.STAGING_WORDPRESS_USER }}
   TF_VAR_wordpress_password: ${{ secrets.STAGING_WORDPRESS_PASSWORD }}
+  TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
   
 permissions:
   id-token: write

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -16,8 +16,8 @@ env:
   TF_VAR_hosted_zone_id: ${{ secrets.PROD_HOSTED_ZONE_ID }}
   TF_VAR_wordpress_user: ${{ secrets.PROD_WORDPRESS_USER }}
   TF_VAR_wordpress_password: ${{ secrets.PROD_WORDPRESS_PASSWORD }}
+  TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
 
-  
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/tf-plan-staging.yml
+++ b/.github/workflows/tf-plan-staging.yml
@@ -17,7 +17,8 @@ env:
   TF_VAR_hosted_zone_id: ${{ secrets.STAGING_HOSTED_ZONE_ID }}
   TF_VAR_wordpress_user: ${{ secrets.STAGING_WORDPRESS_USER }}
   TF_VAR_wordpress_password: ${{ secrets.STAGING_WORDPRESS_PASSWORD }}
-  
+  TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
+
 permissions:
   id-token: write
   contents: read

--- a/terragrunt/aws/variables.tf
+++ b/terragrunt/aws/variables.tf
@@ -40,3 +40,9 @@ variable "wordpress_password" {
   type        = string
   sensitive   = true
 }
+
+variable "upptime_status_header" {
+  description = "The header to check for Upptime status check requests."
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -83,7 +83,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
   }
 
   rule {
-    name     = "GeoRestriction"
+    name     = "CanadaOnlyGeoRestriction"
     priority = 5
 
     action {
@@ -92,7 +92,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
           response_code = 403
           response_header {
             name  = "waf-block"
-            value = "GeoRestriction"
+            value = "CanadaOnlyGeoRestriction"
           }
         }
       }
@@ -101,8 +101,27 @@ resource "aws_wafv2_web_acl" "superset_docs" {
     statement {
       not_statement {
         statement {
-          geo_match_statement {
-            country_codes = ["CA", "US"]
+          or_statement {
+            statement {
+              geo_match_statement {
+                country_codes = ["CA"]
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                field_to_match {
+                  single_header {
+                    name = "upptime"
+                  }
+                }
+                search_string = var.upptime_status_header
+                text_transformation {
+                  priority = 1
+                  type     = "NONE"
+                }
+              }
+            }
           }
         }
       }
@@ -110,7 +129,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "GeoRestriction"
+      metric_name                = "CanadaOnlyGeoRestriction"
       sampled_requests_enabled   = true
     }
   }

--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -83,7 +83,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
   }
 
   rule {
-    name     = "CanadaOnlyGeoRestriction"
+    name     = "GeoRestriction"
     priority = 5
 
     action {
@@ -92,7 +92,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
           response_code = 403
           response_header {
             name  = "waf-block"
-            value = "CanadaOnlyGeoRestriction"
+            value = "GeoRestriction"
           }
         }
       }
@@ -102,7 +102,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
       not_statement {
         statement {
           geo_match_statement {
-            country_codes = ["CA"]
+            country_codes = ["CA", "US"]
           }
         }
       }
@@ -110,7 +110,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "CanadaOnlyGeoRestriction"
+      metric_name                = "GeoRestriction"
       sampled_requests_enabled   = true
     }
   }


### PR DESCRIPTION
# Summary
The status checker's IP address is occasionally being identified as in the US so we're adding a secret Upptime request header that will allow those requests to succeed.