### PR TITLE
chore: upgrade to v1.6.0 release of the GCDS utility library

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1,9 +1,4 @@
-gcds-container :is(h2, h3, h4, h5, h6) {
-    margin-block-start: var(--gcds-spacing-600);
-    margin-block-end: var(--gcds-spacing-300);
-}
-
-gcds-container :is(ol, ul, p, hr) {
+gcds-container :is(ol, ul, hr) {
     margin-block-start: var(--gcds-spacing-0);
     margin-block-end: var(--gcds-spacing-300);
 }
@@ -19,11 +14,6 @@ gcds-container :is(ol li) {
 
 gcds-container :is(ul li) {
     list-style: disc;
-}
-
-gcds-details p {
-    margin-block-start: var(--gcds-spacing-100);
-    margin-block-end: var(--gcds-spacing-100);
 }
 
 gcds-container code {

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -11,7 +11,7 @@
 
   <!-- GC Design System -->
   <link rel="stylesheet"
-    href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-utility@1.5.0/dist/gcds-utility.min.css" />
+    href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-utility@1.6.0/dist/gcds-utility.min.css" />
   <link rel="stylesheet"
     href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.32.0/dist/gcds/gcds.css" />
   <script type="module"


### PR DESCRIPTION
# Summary
Upgrade to the latest release and remove custom CSS styles that are no longer needed.