### PR TITLE
fix: post workflow failure messages to correct env channel

### DIFF
--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -20,7 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'failure'
     steps:
+      - name: Determine target ops channel
+        run: |
+          WORKFLOW_NAME_LOWER="$(echo ${{ github.event.workflow_run.name }} | tr '[:upper:]' '[:lower:]')"
+          if [[ "$WORKFLOW_NAME_LOWER" == *"staging"* ]]; then
+            echo "SLACK_WEBHOOK_URL=${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}" >> $GITHUB_ENV
+          else
+            echo "SLACK_WEBHOOK_URL=${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}" >> $GITHUB_ENV
+          fi
+
       - name: Notify Slack
         run: |
           json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Superset Docs workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ env.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Summary
Update the workflow failure to post notifications to the correct ops channel depending on which environment workflow has failed.