### PR TITLE
feat: add Google Analytics to prod

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,3 +1,4 @@
+GOOGLE_ANALYTICS_ID=""
 PORT="8080"
 SITE_NAME_EN="Site name in English"
 SITE_NAME_FR="Nom du site en français"

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -39,7 +39,7 @@ func main() {
 	// Set up routes
 	http.Handle("/static/", http.StripPrefix("/static/", handlers.NewStaticHandler("static")))
 	http.Handle("/robots.txt", middleware.SecurityHeaders(handlers.NewRobotsHandler()))
-	http.Handle("/", middleware.SecurityHeaders(handlers.NewPageHandler(cfg.GoogleAnalyticsId, siteNames, wordPressClient)))
+	http.Handle("/", middleware.SecurityHeaders(handlers.NewPageHandler(cfg.GoogleAnalyticsID, siteNames, wordPressClient)))
 
 	// Determine if this is a Lambda or HTTP server startup
 	if cfg.Port == "" {

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -39,7 +39,7 @@ func main() {
 	// Set up routes
 	http.Handle("/static/", http.StripPrefix("/static/", handlers.NewStaticHandler("static")))
 	http.Handle("/robots.txt", middleware.SecurityHeaders(handlers.NewRobotsHandler()))
-	http.Handle("/", middleware.SecurityHeaders(handlers.NewPageHandler(siteNames, wordPressClient)))
+	http.Handle("/", middleware.SecurityHeaders(handlers.NewPageHandler(cfg.GoogleAnalyticsId, siteNames, wordPressClient)))
 
 	// Determine if this is a Lambda or HTTP server startup
 	if cfg.Port == "" {

--- a/app/internal/config/config.go
+++ b/app/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 
 // Config holds all application configuration
 type Config struct {
+	GoogleAnalyticsId string
+
 	// Server settings
 	Port       string
 	SiteNameEn string
@@ -51,6 +53,7 @@ func Load() (*Config, error) {
 	}
 
 	// Set optional variables
+	cfg.GoogleAnalyticsId = os.Getenv("GOOGLE_ANALYTICS_ID")
 	cfg.Port = os.Getenv("PORT")
 
 	return cfg, nil

--- a/app/internal/config/config.go
+++ b/app/internal/config/config.go
@@ -7,7 +7,7 @@ import (
 
 // Config holds all application configuration
 type Config struct {
-	GoogleAnalyticsId string
+	GoogleAnalyticsID string
 
 	// Server settings
 	Port       string
@@ -53,7 +53,7 @@ func Load() (*Config, error) {
 	}
 
 	// Set optional variables
-	cfg.GoogleAnalyticsId = os.Getenv("GOOGLE_ANALYTICS_ID")
+	cfg.GoogleAnalyticsID = os.Getenv("GOOGLE_ANALYTICS_ID")
 	cfg.Port = os.Getenv("PORT")
 
 	return cfg, nil

--- a/app/internal/handlers/page.go
+++ b/app/internal/handlers/page.go
@@ -14,16 +14,17 @@ import (
 // fetching the page content from the WordPress API and rendering it using
 // an HTML template.
 type PageHandler struct {
-	SiteNames       map[string]string
-	WordPressClient *api.WordPressClient
-	Templates       *template.Template
+	GoogleAnalyticsId string
+	SiteNames         map[string]string
+	WordPressClient   *api.WordPressClient
+	Templates         *template.Template
 }
 
 var parseTemplateFiles = template.ParseFiles
 
 // NewPageHandler creates a new page handler that will be used
 // to retrieve and render WordPress pages.
-func NewPageHandler(siteNames map[string]string, wordPressClient *api.WordPressClient) *PageHandler {
+func NewPageHandler(googleAnalyticsId string, siteNames map[string]string, wordPressClient *api.WordPressClient) *PageHandler {
 	// Load templates
 	tmpl, err := parseTemplateFiles("templates/layout.html")
 	if err != nil {
@@ -31,9 +32,10 @@ func NewPageHandler(siteNames map[string]string, wordPressClient *api.WordPressC
 	}
 
 	return &PageHandler{
-		SiteNames:       siteNames,
-		WordPressClient: wordPressClient,
-		Templates:       tmpl,
+		GoogleAnalyticsId: googleAnalyticsId,
+		SiteNames:         siteNames,
+		WordPressClient:   wordPressClient,
+		Templates:         tmpl,
 	}
 }
 
@@ -88,7 +90,7 @@ func (h *PageHandler) handlePage(w http.ResponseWriter, _ *http.Request, path st
 		menu = h.WordPressClient.Menus["en"]
 	}
 
-	data := models.NewPageData(page, menu, h.SiteNames, h.WordPressClient.BaseURL)
+	data := models.NewPageData(page, menu, h.GoogleAnalyticsId, h.SiteNames, h.WordPressClient.BaseURL)
 
 	log.Printf("Rendering page template")
 	err = h.Templates.ExecuteTemplate(w, "layout.html", data)

--- a/app/internal/handlers/page.go
+++ b/app/internal/handlers/page.go
@@ -14,7 +14,7 @@ import (
 // fetching the page content from the WordPress API and rendering it using
 // an HTML template.
 type PageHandler struct {
-	GoogleAnalyticsId string
+	GoogleAnalyticsID string
 	SiteNames         map[string]string
 	WordPressClient   *api.WordPressClient
 	Templates         *template.Template
@@ -24,7 +24,7 @@ var parseTemplateFiles = template.ParseFiles
 
 // NewPageHandler creates a new page handler that will be used
 // to retrieve and render WordPress pages.
-func NewPageHandler(googleAnalyticsId string, siteNames map[string]string, wordPressClient *api.WordPressClient) *PageHandler {
+func NewPageHandler(googleAnalyticsID string, siteNames map[string]string, wordPressClient *api.WordPressClient) *PageHandler {
 	// Load templates
 	tmpl, err := parseTemplateFiles("templates/layout.html")
 	if err != nil {
@@ -32,7 +32,7 @@ func NewPageHandler(googleAnalyticsId string, siteNames map[string]string, wordP
 	}
 
 	return &PageHandler{
-		GoogleAnalyticsId: googleAnalyticsId,
+		GoogleAnalyticsID: googleAnalyticsID,
 		SiteNames:         siteNames,
 		WordPressClient:   wordPressClient,
 		Templates:         tmpl,
@@ -90,7 +90,7 @@ func (h *PageHandler) handlePage(w http.ResponseWriter, _ *http.Request, path st
 		menu = h.WordPressClient.Menus["en"]
 	}
 
-	data := models.NewPageData(page, menu, h.GoogleAnalyticsId, h.SiteNames, h.WordPressClient.BaseURL)
+	data := models.NewPageData(page, menu, h.GoogleAnalyticsID, h.SiteNames, h.WordPressClient.BaseURL)
 
 	log.Printf("Rendering page template")
 	err = h.Templates.ExecuteTemplate(w, "layout.html", data)

--- a/app/internal/handlers/page_test.go
+++ b/app/internal/handlers/page_test.go
@@ -120,8 +120,8 @@ func TestNewPageHandler(t *testing.T) {
 		t.Fatal("Expected handler to be created, got nil")
 	}
 
-	if handler.GoogleAnalyticsId != "UA-12345678-9" {
-		t.Errorf("Expected GoogleAnalyticsId to be 'UA-12345678-9', got %s", handler.GoogleAnalyticsId)
+	if handler.GoogleAnalyticsID != "UA-12345678-9" {
+		t.Errorf("Expected GoogleAnalyticsID to be 'UA-12345678-9', got %s", handler.GoogleAnalyticsID)
 	}
 
 	if handler.SiteNames["en"] != "English Site" {
@@ -175,7 +175,7 @@ func TestServeHTTP(t *testing.T) {
 	}
 
 	handler := &PageHandler{
-		GoogleAnalyticsId: "UA-12345678-9",
+		GoogleAnalyticsID: "UA-12345678-9",
 		SiteNames:         siteNames,
 		WordPressClient:   client,
 		Templates:         setupTestTemplates(),
@@ -353,7 +353,7 @@ func TestHandlePage(t *testing.T) {
 
 			// Create handler
 			handler := &PageHandler{
-				GoogleAnalyticsId: "UA-12345678-9",
+				GoogleAnalyticsID: "UA-12345678-9",
 				SiteNames:         map[string]string{"en": "English Site", "fr": "French Site"},
 				WordPressClient:   client,
 				Templates:         setupTestTemplates(),
@@ -421,7 +421,7 @@ func TestTemplateRenderingError(t *testing.T) {
 
 	// Create handler with the error-generating template
 	handler := &PageHandler{
-		GoogleAnalyticsId: "UA-12345678-9",
+		GoogleAnalyticsID: "UA-12345678-9",
 		SiteNames:         map[string]string{"en": "English Site"},
 		WordPressClient:   client,
 		Templates:         errorTemplate,

--- a/app/internal/handlers/page_test.go
+++ b/app/internal/handlers/page_test.go
@@ -113,11 +113,15 @@ func TestNewPageHandler(t *testing.T) {
 	}
 
 	// Create the handler
-	handler := NewPageHandler(siteNames, client)
+	handler := NewPageHandler("UA-12345678-9", siteNames, client)
 
 	// Verify handler was created correctly
 	if handler == nil {
 		t.Fatal("Expected handler to be created, got nil")
+	}
+
+	if handler.GoogleAnalyticsId != "UA-12345678-9" {
+		t.Errorf("Expected GoogleAnalyticsId to be 'UA-12345678-9', got %s", handler.GoogleAnalyticsId)
 	}
 
 	if handler.SiteNames["en"] != "English Site" {
@@ -171,9 +175,10 @@ func TestServeHTTP(t *testing.T) {
 	}
 
 	handler := &PageHandler{
-		SiteNames:       siteNames,
-		WordPressClient: client,
-		Templates:       setupTestTemplates(),
+		GoogleAnalyticsId: "UA-12345678-9",
+		SiteNames:         siteNames,
+		WordPressClient:   client,
+		Templates:         setupTestTemplates(),
 	}
 
 	tests := []struct {
@@ -348,9 +353,10 @@ func TestHandlePage(t *testing.T) {
 
 			// Create handler
 			handler := &PageHandler{
-				SiteNames:       map[string]string{"en": "English Site", "fr": "French Site"},
-				WordPressClient: client,
-				Templates:       setupTestTemplates(),
+				GoogleAnalyticsId: "UA-12345678-9",
+				SiteNames:         map[string]string{"en": "English Site", "fr": "French Site"},
+				WordPressClient:   client,
+				Templates:         setupTestTemplates(),
 			}
 
 			// Create request and response recorder
@@ -415,9 +421,10 @@ func TestTemplateRenderingError(t *testing.T) {
 
 	// Create handler with the error-generating template
 	handler := &PageHandler{
-		SiteNames:       map[string]string{"en": "English Site"},
-		WordPressClient: client,
-		Templates:       errorTemplate,
+		GoogleAnalyticsId: "UA-12345678-9",
+		SiteNames:         map[string]string{"en": "English Site"},
+		WordPressClient:   client,
+		Templates:         errorTemplate,
 	}
 
 	// Create request and response recorder

--- a/app/pkg/models/wordpress.go
+++ b/app/pkg/models/wordpress.go
@@ -41,16 +41,17 @@ type WordPressMenuItem struct {
 
 // PageData holds the data needed to render a page.
 type PageData struct {
-	Lang           string
-	LangSwapPath   string
-	LangSwapSlug   string
-	Home           string
-	Modified       string
-	Title          template.HTML
-	Content        template.HTML
-	ShowBreadcrumb bool
-	SiteName       string
-	Menu           *MenuData
+	GoogleAnalyticsId string
+	Lang              string
+	LangSwapPath      string
+	LangSwapSlug      string
+	Home              string
+	Modified          string
+	Title             template.HTML
+	Content           template.HTML
+	ShowBreadcrumb    bool
+	SiteName          string
+	Menu              *MenuData
 }
 
 // MenuItemData holds the data needed to render a menu item.
@@ -75,7 +76,7 @@ var (
 )
 
 // NewPageData creates a new PageData object that can then be used to render a page.
-func NewPageData(page *WordPressPage, menu *MenuData, siteNames map[string]string, baseUrl string) PageData {
+func NewPageData(page *WordPressPage, menu *MenuData, googleAnalyticsId string, siteNames map[string]string, baseUrl string) PageData {
 	lang := page.Lang
 	if lang != "en" && lang != "fr" {
 		lang = "en"
@@ -92,16 +93,17 @@ func NewPageData(page *WordPressPage, menu *MenuData, siteNames map[string]strin
 	}
 
 	return PageData{
-		Lang:           lang,
-		LangSwapPath:   langPaths[lang].swap,
-		LangSwapSlug:   langPaths[lang].slug,
-		Home:           langPaths[lang].home,
-		Modified:       strings.Split(page.Modified, "T")[0],
-		Title:          template.HTML(page.Title.Rendered),
-		Content:        template.HTML(convertToDesignSystem(page.Content.Rendered, baseUrl)),
-		ShowBreadcrumb: !strings.Contains(page.Slug, "home"),
-		SiteName:       siteNames[lang],
-		Menu:           menu,
+		GoogleAnalyticsId: googleAnalyticsId,
+		Lang:              lang,
+		LangSwapPath:      langPaths[lang].swap,
+		LangSwapSlug:      langPaths[lang].slug,
+		Home:              langPaths[lang].home,
+		Modified:          strings.Split(page.Modified, "T")[0],
+		Title:             template.HTML(page.Title.Rendered),
+		Content:           template.HTML(convertToDesignSystem(page.Content.Rendered, baseUrl)),
+		ShowBreadcrumb:    !strings.Contains(page.Slug, "home"),
+		SiteName:          siteNames[lang],
+		Menu:              menu,
 	}
 }
 

--- a/app/pkg/models/wordpress.go
+++ b/app/pkg/models/wordpress.go
@@ -41,7 +41,7 @@ type WordPressMenuItem struct {
 
 // PageData holds the data needed to render a page.
 type PageData struct {
-	GoogleAnalyticsId string
+	GoogleAnalyticsID string
 	Lang              string
 	LangSwapPath      string
 	LangSwapSlug      string
@@ -76,7 +76,7 @@ var (
 )
 
 // NewPageData creates a new PageData object that can then be used to render a page.
-func NewPageData(page *WordPressPage, menu *MenuData, googleAnalyticsId string, siteNames map[string]string, baseUrl string) PageData {
+func NewPageData(page *WordPressPage, menu *MenuData, googleAnalyticsID string, siteNames map[string]string, baseUrl string) PageData {
 	lang := page.Lang
 	if lang != "en" && lang != "fr" {
 		lang = "en"
@@ -93,7 +93,7 @@ func NewPageData(page *WordPressPage, menu *MenuData, googleAnalyticsId string, 
 	}
 
 	return PageData{
-		GoogleAnalyticsId: googleAnalyticsId,
+		GoogleAnalyticsID: googleAnalyticsID,
 		Lang:              lang,
 		LangSwapPath:      langPaths[lang].swap,
 		LangSwapSlug:      langPaths[lang].slug,

--- a/app/pkg/models/wordpress_test.go
+++ b/app/pkg/models/wordpress_test.go
@@ -11,7 +11,7 @@ func TestNewPageData(t *testing.T) {
 		name              string
 		page              WordPressPage
 		menu              *MenuData
-		googleAnalyticsId string
+		googleAnalyticsID string
 		siteNames         map[string]string
 		baseUrl           string
 		expectedData      PageData
@@ -36,14 +36,14 @@ func TestNewPageData(t *testing.T) {
 			menu: &MenuData{
 				Items: []*MenuItemData{},
 			},
-			googleAnalyticsId: "UA-12345678-9",
+			googleAnalyticsID: "UA-12345678-9",
 			siteNames: map[string]string{
 				"en": "English Site Name",
 				"fr": "French Site Name",
 			},
 			baseUrl: "https://example.com",
 			expectedData: PageData{
-				GoogleAnalyticsId: "UA-12345678-9",
+				GoogleAnalyticsID: "UA-12345678-9",
 				Lang:              "en",
 				LangSwapPath:      "/fr/",
 				LangSwapSlug:      "a-propos",
@@ -75,14 +75,14 @@ func TestNewPageData(t *testing.T) {
 			menu: &MenuData{
 				Items: []*MenuItemData{},
 			},
-			googleAnalyticsId: "UA-12345678-9",
+			googleAnalyticsID: "UA-12345678-9",
 			siteNames: map[string]string{
 				"en": "English Site Name",
 				"fr": "French Site Name",
 			},
 			baseUrl: "https://example.com",
 			expectedData: PageData{
-				GoogleAnalyticsId: "UA-12345678-9",
+				GoogleAnalyticsID: "UA-12345678-9",
 				Lang:              "fr",
 				LangSwapPath:      "/",
 				LangSwapSlug:      "about",
@@ -114,14 +114,14 @@ func TestNewPageData(t *testing.T) {
 			menu: &MenuData{
 				Items: []*MenuItemData{},
 			},
-			googleAnalyticsId: "UA-12345678-9",
+			googleAnalyticsID: "UA-12345678-9",
 			siteNames: map[string]string{
 				"en": "English Site Name",
 				"fr": "French Site Name",
 			},
 			baseUrl: "https://example.com",
 			expectedData: PageData{
-				GoogleAnalyticsId: "UA-12345678-9",
+				GoogleAnalyticsID: "UA-12345678-9",
 				Lang:              "en",
 				LangSwapPath:      "/fr/",
 				LangSwapSlug:      "a-propos",
@@ -153,14 +153,14 @@ func TestNewPageData(t *testing.T) {
 			menu: &MenuData{
 				Items: []*MenuItemData{},
 			},
-			googleAnalyticsId: "UA-12345678-9",
+			googleAnalyticsID: "UA-12345678-9",
 			siteNames: map[string]string{
 				"en": "English Site Name",
 				"fr": "French Site Name",
 			},
 			baseUrl: "https://example.com",
 			expectedData: PageData{
-				GoogleAnalyticsId: "UA-12345678-9",
+				GoogleAnalyticsID: "UA-12345678-9",
 				Lang:              "en",
 				LangSwapPath:      "/fr/",
 				LangSwapSlug:      "accueil",
@@ -180,11 +180,11 @@ func TestNewPageData(t *testing.T) {
 			page := tc.page
 
 			// Call the function being tested
-			result := NewPageData(&page, tc.menu, tc.googleAnalyticsId, tc.siteNames, tc.baseUrl)
+			result := NewPageData(&page, tc.menu, tc.googleAnalyticsID, tc.siteNames, tc.baseUrl)
 
 			// Verify results
-			if result.GoogleAnalyticsId != tc.expectedData.GoogleAnalyticsId {
-				t.Errorf("Expected GoogleAnalyticsId %q, got %q", tc.expectedData.GoogleAnalyticsId, result.GoogleAnalyticsId)
+			if result.GoogleAnalyticsID != tc.expectedData.GoogleAnalyticsID {
+				t.Errorf("Expected GoogleAnalyticsID %q, got %q", tc.expectedData.GoogleAnalyticsID, result.GoogleAnalyticsID)
 			}
 
 			if result.Lang != tc.expectedData.Lang {

--- a/app/pkg/models/wordpress_test.go
+++ b/app/pkg/models/wordpress_test.go
@@ -8,12 +8,13 @@ import (
 // TestNewPageData tests the NewPageData function which creates page rendering data
 func TestNewPageData(t *testing.T) {
 	testCases := []struct {
-		name         string
-		page         WordPressPage
-		menu         *MenuData
-		siteNames    map[string]string
-		baseUrl      string
-		expectedData PageData
+		name              string
+		page              WordPressPage
+		menu              *MenuData
+		googleAnalyticsId string
+		siteNames         map[string]string
+		baseUrl           string
+		expectedData      PageData
 	}{
 		{
 			name: "English page",
@@ -35,21 +36,23 @@ func TestNewPageData(t *testing.T) {
 			menu: &MenuData{
 				Items: []*MenuItemData{},
 			},
+			googleAnalyticsId: "UA-12345678-9",
 			siteNames: map[string]string{
 				"en": "English Site Name",
 				"fr": "French Site Name",
 			},
 			baseUrl: "https://example.com",
 			expectedData: PageData{
-				Lang:           "en",
-				LangSwapPath:   "/fr/",
-				LangSwapSlug:   "a-propos",
-				Home:           "/",
-				Modified:       "2023-05-15",
-				Title:          "About Us",
-				Content:        "<p>This is content with /image.jpg</p>",
-				ShowBreadcrumb: true,
-				SiteName:       "English Site Name",
+				GoogleAnalyticsId: "UA-12345678-9",
+				Lang:              "en",
+				LangSwapPath:      "/fr/",
+				LangSwapSlug:      "a-propos",
+				Home:              "/",
+				Modified:          "2023-05-15",
+				Title:             "About Us",
+				Content:           "<p>This is content with /image.jpg</p>",
+				ShowBreadcrumb:    true,
+				SiteName:          "English Site Name",
 			},
 		},
 		{
@@ -72,21 +75,23 @@ func TestNewPageData(t *testing.T) {
 			menu: &MenuData{
 				Items: []*MenuItemData{},
 			},
+			googleAnalyticsId: "UA-12345678-9",
 			siteNames: map[string]string{
 				"en": "English Site Name",
 				"fr": "French Site Name",
 			},
 			baseUrl: "https://example.com",
 			expectedData: PageData{
-				Lang:           "fr",
-				LangSwapPath:   "/",
-				LangSwapSlug:   "about",
-				Home:           "/fr/",
-				Modified:       "2023-05-15",
-				Title:          "À propos",
-				Content:        "<p>C'est du contenu avec /image.jpg</p>",
-				ShowBreadcrumb: true,
-				SiteName:       "French Site Name",
+				GoogleAnalyticsId: "UA-12345678-9",
+				Lang:              "fr",
+				LangSwapPath:      "/",
+				LangSwapSlug:      "about",
+				Home:              "/fr/",
+				Modified:          "2023-05-15",
+				Title:             "À propos",
+				Content:           "<p>C'est du contenu avec /image.jpg</p>",
+				ShowBreadcrumb:    true,
+				SiteName:          "French Site Name",
 			},
 		},
 		{
@@ -109,21 +114,23 @@ func TestNewPageData(t *testing.T) {
 			menu: &MenuData{
 				Items: []*MenuItemData{},
 			},
+			googleAnalyticsId: "UA-12345678-9",
 			siteNames: map[string]string{
 				"en": "English Site Name",
 				"fr": "French Site Name",
 			},
 			baseUrl: "https://example.com",
 			expectedData: PageData{
-				Lang:           "en",
-				LangSwapPath:   "/fr/",
-				LangSwapSlug:   "a-propos",
-				Home:           "/",
-				Modified:       "2023-05-15",
-				Title:          "About Us",
-				Content:        "<p>Content</p>",
-				ShowBreadcrumb: true,
-				SiteName:       "English Site Name",
+				GoogleAnalyticsId: "UA-12345678-9",
+				Lang:              "en",
+				LangSwapPath:      "/fr/",
+				LangSwapSlug:      "a-propos",
+				Home:              "/",
+				Modified:          "2023-05-15",
+				Title:             "About Us",
+				Content:           "<p>Content</p>",
+				ShowBreadcrumb:    true,
+				SiteName:          "English Site Name",
 			},
 		},
 		{
@@ -146,21 +153,23 @@ func TestNewPageData(t *testing.T) {
 			menu: &MenuData{
 				Items: []*MenuItemData{},
 			},
+			googleAnalyticsId: "UA-12345678-9",
 			siteNames: map[string]string{
 				"en": "English Site Name",
 				"fr": "French Site Name",
 			},
 			baseUrl: "https://example.com",
 			expectedData: PageData{
-				Lang:           "en",
-				LangSwapPath:   "/fr/",
-				LangSwapSlug:   "accueil",
-				Home:           "/",
-				Modified:       "2023-05-15",
-				Title:          "Home Page",
-				Content:        "<p>Welcome home</p>",
-				ShowBreadcrumb: false, // Home page, no breadcrumb
-				SiteName:       "English Site Name",
+				GoogleAnalyticsId: "UA-12345678-9",
+				Lang:              "en",
+				LangSwapPath:      "/fr/",
+				LangSwapSlug:      "accueil",
+				Home:              "/",
+				Modified:          "2023-05-15",
+				Title:             "Home Page",
+				Content:           "<p>Welcome home</p>",
+				ShowBreadcrumb:    false, // Home page, no breadcrumb
+				SiteName:          "English Site Name",
 			},
 		},
 	}
@@ -171,9 +180,13 @@ func TestNewPageData(t *testing.T) {
 			page := tc.page
 
 			// Call the function being tested
-			result := NewPageData(&page, tc.menu, tc.siteNames, tc.baseUrl)
+			result := NewPageData(&page, tc.menu, tc.googleAnalyticsId, tc.siteNames, tc.baseUrl)
 
 			// Verify results
+			if result.GoogleAnalyticsId != tc.expectedData.GoogleAnalyticsId {
+				t.Errorf("Expected GoogleAnalyticsId %q, got %q", tc.expectedData.GoogleAnalyticsId, result.GoogleAnalyticsId)
+			}
+
 			if result.Lang != tc.expectedData.Lang {
 				t.Errorf("Expected Lang %q, got %q", tc.expectedData.Lang, result.Lang)
 			}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -20,13 +20,13 @@
   <!-- Custom styles -->
   <link rel="stylesheet" href="/static/css/styles.css">
 
-  {{if .GoogleAnalyticsId}}
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{.GoogleAnalyticsId}}"></script>
+  {{if .GoogleAnalyticsID}}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{.GoogleAnalyticsID}}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', '{{.GoogleAnalyticsId}}');
+    gtag('config', '{{.GoogleAnalyticsID}}');
   </script>
   {{end}}
 </head>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -19,6 +19,16 @@
 
   <!-- Custom styles -->
   <link rel="stylesheet" href="/static/css/styles.css">
+
+  {{if .GoogleAnalyticsId}}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{.GoogleAnalyticsId}}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '{{.GoogleAnalyticsId}}');
+  </script>
+  {{end}}
 </head>
 
 <body>

--- a/terragrunt/aws/lambda.tf
+++ b/terragrunt/aws/lambda.tf
@@ -10,6 +10,7 @@ module "superset_docs" {
   enable_lambda_insights = true
 
   environment_variables = {
+    GOOGLE_ANALYTICS_ID  = var.google_analytics_id
     SITE_NAME_EN         = var.site_name_en
     SITE_NAME_FR         = var.site_name_fr
     WORDPRESS_MENU_ID_EN = var.menu_id_en

--- a/terragrunt/aws/variables.tf
+++ b/terragrunt/aws/variables.tf
@@ -1,3 +1,8 @@
+variable "google_analytics_id" {
+  description = "The Google Analytics ID"
+  type        = string
+}
+
 variable "hosted_zone_id" {
   description = "The Route53 hosted zone ID"
   type        = string

--- a/terragrunt/env/prod/terragrunt.hcl
+++ b/terragrunt/env/prod/terragrunt.hcl
@@ -7,9 +7,10 @@ include {
 }
 
 inputs = {
-  menu_id_en    = "9"
-  menu_id_fr    = "10"
-  site_name_en  = "Superset Docs"
-  site_name_fr  = "Docs de Superset"
-  wordpress_url = "https://articles.alpha.canada.ca/pcs-superset"
+  google_analytics_id = "G-V4D2DCT007"
+  menu_id_en          = "9"
+  menu_id_fr          = "10"
+  site_name_en        = "Superset Docs"
+  site_name_fr        = "Docs de Superset"
+  wordpress_url       = "https://articles.alpha.canada.ca/pcs-superset"
 }

--- a/terragrunt/env/staging/terragrunt.hcl
+++ b/terragrunt/env/staging/terragrunt.hcl
@@ -7,9 +7,10 @@ include {
 }
 
 inputs = {
-  menu_id_en    = "9"
-  menu_id_fr    = "10"
-  site_name_en  = "Superset Docs"
-  site_name_fr  = "Docs de Superset"
-  wordpress_url = "https://articles.alpha.canada.ca/pcs-superset"
+  google_analytics_id = ""
+  menu_id_en          = "9"
+  menu_id_fr          = "10"
+  site_name_en        = "Superset Docs"
+  site_name_fr        = "Docs de Superset"
+  wordpress_url       = "https://articles.alpha.canada.ca/pcs-superset"
 }


### PR DESCRIPTION
# Summary
Update the site so that if a Google Analytics ID is provided, the tracking JavaScript is also loaded on the page.

This will allow us to selectively deploy different tracking IDs to different environments, or omit environments from tracking.

# Related
- https://github.com/cds-snc/platform-core-services/issues/744