### PR TITLE
fix: race condition to retrieve commit SHA

### DIFF
--- a/.github/workflows/docker-deploy-staging.yml
+++ b/.github/workflows/docker-deploy-staging.yml
@@ -10,7 +10,7 @@ env:
   AWS_REGION: ca-central-1
   FUNCTION_NAME: cds-superset-docs
   REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/cds-superset-docs
-  IMAGE_TAG: sha-${{ github.sha }}
+  IMAGE_TAG: sha-${{ github.event.workflow_run.head_sha }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
# Summary
Update the Docker deploy workflow so they use the commit SHA of the `main` branch commit that triggered its invocation.