### PR TITLE
feat: add Lambda restart workflows

### DIFF
--- a/.github/workflows/cache-invalidate-staging.yml
+++ b/.github/workflows/cache-invalidate-staging.yml
@@ -3,7 +3,9 @@ name: Cache invalidate Staging
 on:
   repository_dispatch:
   workflow_run:
-    workflows: ["Docker deploy Staging"]
+    workflows:
+    - "Docker deploy Staging"
+    - "Lambda restart Staging"
     types:
     - completed
 

--- a/.github/workflows/lambda-restart-prod.yml
+++ b/.github/workflows/lambda-restart-prod.yml
@@ -1,23 +1,17 @@
-name: Cache invalidate Production
+name: Lambda restart Production
 
 on:
-  repository_dispatch:
-  workflow_run:
-    workflows:
-    - "Docker deploy Production"
-    - "Lambda restart Production"
-    types:
-    - completed
+  workflow_dispatch:
 
 env: 
   AWS_REGION: ca-central-1
+  FUNCTION_NAME: cds-superset-docs
 
 permissions:
   id-token: write
 
 jobs:
-  cache-invalidate:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  lambda-restart:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,12 +26,12 @@ jobs:
       uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
       with:
         role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-docs-apply 
-        role-session-name: CacheInvalidate
+        role-session-name: RestartLambda
         aws-region: ${{ env.AWS_REGION }}
 
-    - name: Invalidate CloudFront cache
+    - name: Restart Lambda function
       run: |
-        DISTRIBUTION_ID="$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[?contains(@,'docs.superset')]].Id" --output text)"
-        aws cloudfront create-invalidation \
-          --distribution-id "$DISTRIBUTION_ID" \
-          --paths "/*"
+        aws lambda update-function-code \
+          --function-name ${{ env.FUNCTION_NAME }} \
+          --description "Updated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')" > /dev/null 2>&1
+

--- a/.github/workflows/lambda-restart-staging.yml
+++ b/.github/workflows/lambda-restart-staging.yml
@@ -1,0 +1,37 @@
+name: Lambda restart Staging
+
+on:
+  workflow_dispatch:
+
+env: 
+  AWS_REGION: ca-central-1
+  FUNCTION_NAME: cds-superset-docs
+
+permissions:
+  id-token: write
+
+jobs:
+  lambda-restart:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Audit DNS requests
+      uses: cds-snc/dns-proxy-action@main
+      env:
+        DNS_PROXY_FORWARDTOSENTINEL: "true"
+        DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+        DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+    - name: Configure aws credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+      with:
+        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-docs-apply
+        role-session-name: RestartLambda
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Restart Lambda function
+      run: |
+        aws lambda update-function-code \
+          --function-name ${{ env.FUNCTION_NAME }} \
+          --description "Updated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')" > /dev/null 2>&1
+


### PR DESCRIPTION
# Summary
Add workflows that can be used to force a restart of the site's Lambda function.  This can be used when there are WordPress menu changes made that should be reflected on the site.

Additionally, once the Lambda restart workflow is finished it will also trigger a cache invalidation.