### PR TITLE
fix: update to use correct AWS CLI command

### DIFF
--- a/.github/workflows/lambda-restart-prod.yml
+++ b/.github/workflows/lambda-restart-prod.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Restart Lambda function
       run: |
-        aws lambda update-function-code \
+        aws lambda update-function-configuration \
           --function-name ${{ env.FUNCTION_NAME }} \
           --description "Updated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')" > /dev/null 2>&1
 

--- a/.github/workflows/lambda-restart-staging.yml
+++ b/.github/workflows/lambda-restart-staging.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Restart Lambda function
       run: |
-        aws lambda update-function-code \
+        aws lambda update-function-configuration \
           --function-name ${{ env.FUNCTION_NAME }} \
           --description "Updated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')" > /dev/null 2>&1
 


### PR DESCRIPTION
# Summary
Update the restart Lambda workflow to use the correct AWL CLI command needed to update a function's description.