### PR TITLE
feat: add Slack notification for Security PRs

### DIFF
--- a/.github/workflows/dependency-security-update.yml
+++ b/.github/workflows/dependency-security-update.yml
@@ -1,0 +1,31 @@
+name: Dependency Security Updates
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-security-update:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, '[security]') && github.actor == 'renovate[bot]'
+    steps:
+      - name: Send Slack notification
+        run: |
+          curl \
+            --request POST \
+            --header 'Content-type: application/json' \
+            --data "{
+              \"blocks\": [
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \"🔒 Security dependency PR opened for Superset Docs:\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>\"
+                  }
+                }
+              ]
+            }" \
+            ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}


### PR DESCRIPTION
# Summary
Add a workflow that posts to Slack when a new dependency security PR is opened by Renovate.

# Related
- https://github.com/cds-snc/platform-core-services/issues/764