### PR TITLE
feat: enable http3 support and switch to HTTPS DNS record

### DIFF
--- a/terragrunt/aws/cloudfront.tf
+++ b/terragrunt/aws/cloudfront.tf
@@ -1,8 +1,9 @@
 resource "aws_cloudfront_distribution" "superset_docs" {
-  enabled     = true
-  aliases     = [var.domain]
-  price_class = "PriceClass_100"
-  web_acl_id  = aws_wafv2_web_acl.superset_docs.arn
+  enabled      = true
+  aliases      = [var.domain]
+  price_class  = "PriceClass_100"
+  web_acl_id   = aws_wafv2_web_acl.superset_docs.arn
+  http_version = "http2and3"
 
   origin {
     domain_name = local.superset_docs_function_url

--- a/terragrunt/aws/route53.tf
+++ b/terragrunt/aws/route53.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_record" "superset_docs_A" {
   zone_id = var.hosted_zone_id
   name    = var.domain
-  type    = "A"
+  type    = "HTTPS"
 
   alias {
     name                   = aws_cloudfront_distribution.superset_docs.domain_name


### PR DESCRIPTION
# Summary
Update the CloudFront distribution to support http2 and http3.  Additionally change the DNS `A` record to an `HTTPS` record which speeds up the connection handshake and improved performance.
