### PR TITLE
fix: updated ja4 rules

### DIFF
--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -101,7 +101,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
     priority = 20
 
     action {
-      block {}
+      challenge {}
     }
 
     statement {
@@ -111,7 +111,7 @@ resource "aws_wafv2_web_acl" "superset_docs" {
 
         custom_key {
           ja4_fingerprint {
-            fallback_behavior = "MATCH"
+            fallback_behavior = "NO_MATCH"
           }
         }
       }


### PR DESCRIPTION
# Summary | Résumé

Updated the RateLimitAllRequestsJA4 WAF rule in `waf.tf` with two fixes:

- changed action from `block` to `challenge`, this will prevent legitimate users from being hard-blocked if the rate limit is incorrectly triggered again
- changed fallback behaviour from 'MATCH' to `NO_MATCH` behaviour if a fingerprint cannot be determine to prevent accidental aggregation with legitimate traffic.

# Related
- https://github.com/cds-snc/platform-core-services/issues/1003
- https://github.com/cds-snc/platform-core-services/issues/1011
